### PR TITLE
fix(generator): sort generated imports deterministically

### DIFF
--- a/internal/generator/generator.go
+++ b/internal/generator/generator.go
@@ -3,6 +3,7 @@ package generator
 
 import (
 	"fmt"
+	"sort"
 	"strings"
 
 	"github.com/pangobit/go-wrangler/internal/parse"
@@ -166,8 +167,14 @@ func GeneratePackage(structs []parse.StructInfo, pkgName string) string {
 	}
 
 	if len(importSet) > 0 {
-		sb.WriteString("import (\n")
+		imports := make([]string, 0, len(importSet))
 		for imp := range importSet {
+			imports = append(imports, imp)
+		}
+		sort.Strings(imports)
+
+		sb.WriteString("import (\n")
+		for _, imp := range imports {
 			sb.WriteString("\t\"" + imp + "\"\n")
 		}
 		sb.WriteString(")\n\n")

--- a/internal/generator/generator_test.go
+++ b/internal/generator/generator_test.go
@@ -1,6 +1,7 @@
 package generator
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/pangobit/go-wrangler/internal/parse"
@@ -198,5 +199,41 @@ func BindModifier(r *http.Request, s *Modifier) error {
 	}
 	if !hasStrconv {
 		t.Errorf("Expected strconv import for float64 binding")
+	}
+}
+
+func TestGeneratePackageSortsImportsDeterministically(t *testing.T) {
+	structs := []parse.StructInfo{
+		{
+			Name: "User",
+			Tags: []parse.TagInfo{
+				{
+					FieldName: "Name",
+					FieldType: "string",
+					Bind: &parse.BindTag{
+						Type: "header",
+					},
+				},
+			},
+		},
+		{
+			Name: "Modifier",
+			Tags: []parse.TagInfo{
+				{
+					FieldName: "Value",
+					FieldType: "float64",
+					Bind: &parse.BindTag{
+						Type: "form",
+					},
+				},
+			},
+		},
+	}
+
+	code := GeneratePackage(structs, "generated")
+
+	expectedImportBlock := "import (\n\t\"fmt\"\n\t\"net/http\"\n\t\"strconv\"\n)\n\n"
+	if !strings.Contains(code, expectedImportBlock) {
+		t.Fatalf("GeneratePackage() import block = %q, want ordered block %q", code, expectedImportBlock)
 	}
 }


### PR DESCRIPTION
Avoid diff noise caused by non-deterministic import ordering in generated files.

  GeneratePackage was collecting imports in a map and ranging over it
  directly, which let Go's randomized map iteration reorder imports
across
  runs. Sort the deduplicated import list before emitting the import
block
  and add a regression test covering the stable fmt/net/http/strconv
order.